### PR TITLE
Implement batch schemapart writing for improved performance

### DIFF
--- a/commands/load.lua
+++ b/commands/load.lua
@@ -36,6 +36,7 @@ function blockexchange.load(playername, pos1, username, schemaname, from_mtime)
 
 		-- current schemapart
 		local schemapart
+		local batch = blockexchange.create_batch_placer(pos1)
 
 		while true do
 			if mtime > 0 then
@@ -49,7 +50,17 @@ function blockexchange.load(playername, pos1, username, schemaname, from_mtime)
 					-- success
 					current_part = current_part + 1
 					mtime = schemapart.mtime
-					blockexchange.place_schemapart(schemapart, pos1)
+					batch:add(schemapart)
+
+					if #batch.parts >= blockexchange.batch_size then
+						batch:flush()
+
+						local progress_percent = math.floor(current_part / total_parts * 100 * 10) / 10
+						job.hud_text = "Downloading '" .. username .. "/" .. schemaname ..
+							"', progress: " .. progress_percent .. " %"
+
+						await(Promise.after(blockexchange.min_delay))
+					end
 				else
 					-- no more schemaparts
 					break
@@ -66,42 +77,43 @@ function blockexchange.load(playername, pos1, username, schemaname, from_mtime)
 					elseif not schemapart then
 						-- empty schema
 						break
-					else
-						current_part = current_part + 1
-						blockexchange.place_schemapart(schemapart, pos1)
-					end
-				else
-					-- other parts
-					local pos = {
-						x = schemapart.offset_x,
-						y = schemapart.offset_y,
-						z = schemapart.offset_z
-					}
-					schemapart, err = await(blockexchange.api.get_next_schemapart(schema.uid, pos))
-					if err then
-						retries = retries + 1
-						await(Promise.after(5))
-					elseif not schemapart then
-						-- done
-						break
-					else
-						current_part = current_part + 1
-						blockexchange.place_schemapart(schemapart, pos1)
 					end
 				end
+
+				current_part = current_part + 1
+				batch:add(schemapart)
+
+				if #batch.parts >= blockexchange.batch_size then
+					batch:flush()
+
+					local progress_percent = math.floor(current_part / total_parts * 100 * 10) / 10
+					job.hud_text = "Downloading '" .. username .. "/" .. schemaname ..
+						"', progress: " .. progress_percent .. " %"
+
+					await(Promise.after(blockexchange.min_delay))
+				end
+
+				local pos = {
+					x = schemapart.offset_x,
+					y = schemapart.offset_y,
+					z = schemapart.offset_z
+				}
+				schemapart, err = await(blockexchange.api.get_next_schemapart(schema.uid, pos))
+				if err then
+					retries = retries + 1
+					await(Promise.after(5))
+				elseif not schemapart then
+					break
+				end
 			end
-
-			-- compute stats
-			local progress_percent = math.floor(current_part / total_parts * 100 * 10) / 10
-			job.hud_text = "Downloading '" .. username .. "/" .. schemaname ..
-				"', progress: " .. progress_percent .. " %"
-
-			await(Promise.after(blockexchange.min_delay))
 
 			if job.cancel then
 				error("canceled", 0)
 			end
 		end
+
+		batch:flush()
+		job.hud_text = "Downloading '" .. username .. "/" .. schemaname .. "', complete!"
 
 		local player_settings = blockexchange.get_player_settings(playername)
 		if player_settings.area_tracking and initial_load then

--- a/commands/load_local.lua
+++ b/commands/load_local.lua
@@ -31,15 +31,24 @@ function blockexchange.load_local(playername, origin, schemaname)
         local pos2 = vector.add(origin, blockexchange.get_schema_size(schema))
         pos2 = vector.subtract(pos2, 1)
         blockexchange.set_pos(2, playername, pos2)
-        local total_parts = blockexchange.count_schemaparts(origin, pos2)
+
+        local total_parts = 0
+        for current_pos in blockexchange.iterator(origin, origin, pos2) do
+			local relative_pos = vector.subtract(current_pos, origin)
+			local entry_filename = "schemapart_" .. relative_pos.x .. "_" .. relative_pos.y .. "_" .. relative_pos.z .. ".json"
+			if zip:get_entry(entry_filename) then
+				total_parts = total_parts + 1
+			end
+		end
+
+		local batch = blockexchange.create_batch_placer(origin)
 
 		for current_pos in blockexchange.iterator(origin, origin, pos2) do
-            -- TODO: maybe iterate over files instead of map-parts
 			local relative_pos = vector.subtract(current_pos, origin)
 			local entry_filename = "schemapart_" .. relative_pos.x .. "_" .. relative_pos.y .. "_" .. relative_pos.z .. ".json"
 			local entry = zip:get_entry(entry_filename)
 			if entry then
-				-- non-air part
+                -- non-air part
                 local schemapart_str
 				schemapart_str, err = zip:get(entry_filename, true)
 				if err then
@@ -47,21 +56,29 @@ function blockexchange.load_local(playername, origin, schemaname)
 				end
 				local schemapart = minetest.parse_json(schemapart_str)
 
-				-- increment stats
+                -- increment stats
 				current_part = current_part + 1
-				local progress_percent = math.floor(current_part / total_parts * 100 * 10) / 10
-                job.hud_text = "Local download '" .. schemaname ..
-				    "', progress: " .. progress_percent .. " %"
+				batch:add(schemapart)
 
-				blockexchange.place_schemapart(schemapart, origin)
+				local progress_percent = math.floor(current_part / total_parts * 100 * 10) / 10
+				job.hud_text = "Local download '" .. schemaname ..
+					"', progress: " .. progress_percent .. " %"
+
+				if #batch.parts >= blockexchange.batch_size then
+					batch:flush()
+					await(Promise.after(blockexchange.min_delay))
+				end
+
 				minetest.log("action", "[blockexchange] Extraction of part " .. minetest.pos_to_string(current_pos) .. " completed")
 			end
 
 			if job.cancel then
 				error("canceled", 0)
 			end
-			await(Promise.after(blockexchange.min_delay))
 		end
+
+		batch:flush()
+		job.hud_text = "Local download '" .. schemaname .. "', complete!"
 
 		return {
             total_parts = total_parts

--- a/init.lua
+++ b/init.lua
@@ -14,7 +14,8 @@ blockexchange = {
 	min_delay = 0.1,
 	pos1 = {}, -- name -> pos
 	pos2 = {}, -- name -> pos
-	max_size = 1000
+	max_size = 1000,
+	batch_size = tonumber(minetest.settings:get("blockexchange.batch_size")) or 20
 }
 
 -- min-delay for async operations

--- a/readme.md
+++ b/readme.md
@@ -93,6 +93,7 @@ Online commands, they call the remote-server with the http api
 # Settings
 
 * **blockexchange.url** URL to the central server
+* **blockexchange.batch_size** (default: 20) Number of schemaparts to place in one batch (performance tuning)
 
 The mod also needs the http api:
 ```

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -3,3 +3,6 @@ blockexchange.url (blockexchange server url) string https://blockexchange.minete
 
 # the min-delay for http calls
 blockexchange.min_delay (min delay between http calls) float 0.1
+
+# number of schemaparts to batch before writing to map (higher = faster but more memory and longer stutters)
+blockexchange.batch_size (schemapart batch size) int 20 1 100

--- a/util/place_schemapart.lua
+++ b/util/place_schemapart.lua
@@ -20,3 +20,41 @@ function blockexchange.place_schemapart(schemapart, origin, update_light)
 
 	return pos1, pos2, data, metadata
 end
+
+-- creates a batch context for placing multiple schemaparts efficiently
+-- returns batch context object with add() and flush() methods
+function blockexchange.create_batch_placer(origin)
+	local batch = {
+		origin = origin,
+		parts = {}
+	}
+
+	function batch:add(schemapart)
+		table.insert(self.parts, schemapart)
+	end
+
+	function batch:flush()
+		if #self.parts == 0 then
+			return
+		end
+
+		for _, schemapart in ipairs(self.parts) do
+			local data, metadata = blockexchange.unpack_schemapart(schemapart)
+			local pos1 = vector.add(self.origin, {
+				x = schemapart.offset_x,
+				y = schemapart.offset_y,
+				z = schemapart.offset_z
+			})
+			local pos2 = vector.add(pos1, vector.subtract(metadata.size, 1))
+			blockexchange.deserialize_part(pos1, pos2, data, metadata, true)
+
+			if has_mapsync then
+				mapsync.mark_changed(pos1, pos2)
+			end
+		end
+
+		self.parts = {}
+	end
+
+	return batch
+end

--- a/util/place_schemapart.lua
+++ b/util/place_schemapart.lua
@@ -39,18 +39,7 @@ function blockexchange.create_batch_placer(origin)
 		end
 
 		for _, schemapart in ipairs(self.parts) do
-			local data, metadata = blockexchange.unpack_schemapart(schemapart)
-			local pos1 = vector.add(self.origin, {
-				x = schemapart.offset_x,
-				y = schemapart.offset_y,
-				z = schemapart.offset_z
-			})
-			local pos2 = vector.add(pos1, vector.subtract(metadata.size, 1))
-			blockexchange.deserialize_part(pos1, pos2, data, metadata, true)
-
-			if has_mapsync then
-				mapsync.mark_changed(pos1, pos2)
-			end
+			blockexchange.place_schemapart(schemapart, self.origin, true)
 		end
 
 		self.parts = {}


### PR DESCRIPTION
VoxelManips are quite fast at writing on the map, but the overhead of using single MapBlocks as units proved to be a bottleneck due to repeated write operations and waiting delays when trying to paste big schematics (2k+ parts). This PR introduces a batching mechanism that accumulates multiple schema parts (default 20) and writes them to the map in a single pass. It doesn't solve the problem of sequential downloading a lot of parts from the server (which, btw, I saw that a `get_schemapart_chunk` function exists but it's not used...?) but it helps when using a local file at least (with ~2400 parts it now takes ~30s instead of >6m - I never waited for the non-batch one to actually finish so I'm not sure about the real total time but well... it's a big improvement).

I also updated the local loading progress calculation to count actual zip entries instead of the total geometric volume, as suggested by the TODO.

